### PR TITLE
[Finishes #150911899] Forward Ping request to `k` neighbors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_libraries(${PROJECT_NAME}
         ${SWIM_LIBS})
 
 if (NOT ${INSTALL_DIR})
-    message(STATUS "Installing lib${PROJECT_NAME}.a static library to ${INSTALL_DIR}/lib\n"
+    message(STATUS "Installing lib${PROJECT_NAME}.so shared library to ${INSTALL_DIR}/lib\n"
                    "   and include files to ${INSTALL_DIR}/include/${PROJECT_NAME}")
     install(TARGETS ${PROJECT_NAME} DESTINATION ${INSTALL_DIR}/lib)
 
@@ -143,9 +143,8 @@ target_link_libraries(swim_server_demo
 ##
 # Gossip Server
 #
-# Full implementation of the `GossipFailureDetector` with associated HTTP REST API.
+# Full implementation of the `GossipFailureDetector`.
 #
-link_directories(${INSTALL_DIR}/lib)
 add_executable(gossip_detector_example
         ${SOURCE_DIR}/examples/gossip_example.cpp
 )

--- a/proto/swim.proto
+++ b/proto/swim.proto
@@ -7,8 +7,10 @@
 // in the README doc.
 package swim;
 
-// We don't need reflection or any of the other features not supported by `MessageLite`.
-option optimize_for = LITE_RUNTIME;
+// We still want reflection and the full-fat version of Protobuf, but we can try to optimize for
+// code size.
+// See: https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message_lite
+option optimize_for = CODE_SIZE;
 
 // A running SWIM service is uniquely identified by the hostname:port combination.
 // The optional IP address is only provided to help in those deployment where DNS

--- a/src/swim/SwimCommon.hpp
+++ b/src/swim/SwimCommon.hpp
@@ -18,7 +18,7 @@ using Timestamp = system_clock::time_point;
 
 namespace swim {
 
-////  All CONSTANTS should be defined here for ease of reference  ///
+////  Mark: Constants
 
 /** Default timeout for all clients connecting to servers */
 const unsigned long kDefaultTimeoutMsec = 25;
@@ -38,6 +38,7 @@ const static double kTimeDecayConstant = 0.01;
 /** Reporting budget, currently set to cutoff at around 2 minutes, with constant messages. */
 const static double kTimeDecayBudget = 300.0;
 
+//// Constants end.
 
 
 inline ::google::protobuf::uint64 TimestampToFixed64(const Timestamp &timestamp) {

--- a/src/swim/SwimServer.hpp
+++ b/src/swim/SwimServer.hpp
@@ -90,9 +90,9 @@ class SwimServer {
    *    timestamp and added from the most recent backwards, until the budget is reached
    * @param which whether to add the records to the `alive` or `suspected` list
    */
-  void addRecordsToBudget(SwimReport &report,
+  void AddRecordsToBudget(SwimReport &report,
                           std::vector<ServerRecord> &records,
-                          const ReportSelector& which = kAlive) const;
+                          const ReportSelector &which = kAlive) const;
 protected:
 
   /**
@@ -104,7 +104,7 @@ protected:
    * @param client the server that just sent the message; the callee obtains ownership of the
    *        pointer and is responsible for freeing the memory.
    */
-  virtual void onUpdate(Server *client);
+  virtual void OnUpdate(Server *client);
 
   /**
    * Invoked when the `client` sends a `SwimEnvelope::Type::STATUS_REPORT` message to this server.
@@ -117,7 +117,7 @@ protected:
    * @param report the `SwimReport` that the `client` sent and can be used by this server to
    *        update its membership list.
    */
-  virtual void onReport(Server *sender, SwimReport *report);
+  virtual void OnReport(Server *sender, SwimReport *report);
 
   /**
    * Invoked when the `client` sends a `SwimEnvelope::Type::STATUS_REQUEST` message to this server.
@@ -125,8 +125,8 @@ protected:
    * <p>This is essentially a callback method that will be invoked by the server's loop, in its
    * own thread.
    *
-   * <p>This message requests this server to send a report on behalf of the `sender`, to
-   * the `destination` server; the latter, if indeed alive, will then contact back the original
+   * <p>This message requests this server to ping the `destination` server, on behalf of the 
+   * `sender`; the latter, if indeed alive, will then contact back the original
    * `sender` to update its status.
    *
    * <p>If the `destination` does not respond, no action is taken, beyond marking it as a
@@ -137,7 +137,7 @@ protected:
    * @param destination the that the requestor (`sender`) is asksing this server to try and reach.
    *        This method is responsible for freeing the memory.
    */
-  virtual void onPingRequest(Server *sender, Server *destination);
+  virtual void OnForwardRequest(Server *sender, Server *destination);
 
 public:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(${TEST_TARGET}
 )
 target_link_libraries(${TEST_TARGET}
         ${GTEST}
+        protobuf
         distlib
 )
 


### PR DESCRIPTION
Last part of the SWIM protocol: when a server is "suspected"
a request to ping it is forwarded to `k` neighbors, so that they
can ping it too.